### PR TITLE
Display React's Native features requests vote issue link when installing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
         "type": "git",
         "url": "github.com/archriss/react-native-snap-carousel"
     },
+    "scripts" : {
+  	    "postinstall" : "echo 'Do you want an even better plugin? Vote for React Native s feature requests(https://github.com/archriss/react-native-snap-carousel/issues/203) to let the Facebook team know what they need to improve!'"
+    },
     "keywords": [
         "react",
         "native",


### PR DESCRIPTION
Display the following message when the user installs the plugin (npm only):
`"Do you want an even better plugin? Vote for React Native s feature requests(https://github.com/archriss/react-native-snap-carousel/issues/203) to let the Facebook team know what they need to improve!"`


see https://github.com/archriss/react-native-snap-carousel/pull/214#issuecomment-344023270 for more explanation and screenshot