### PR TITLE
Remove activeIndex check in snapToItem

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1129,10 +1129,6 @@ export default class Carousel extends Component {
 
         const positionIndex = this._getPositionIndex(index);
 
-        if (positionIndex === this._activeItem) {
-            return;
-        }
-
         this._snapToItem(positionIndex, animated, fireCallback);
     }
 


### PR DESCRIPTION
### Platforms affected
ios/android

### What does this PR do?
Allows for programmatic snapping to the current active index on the carousel, allowing for controlled re-centering of the carousel programmatically when automatic snapping is disabled.

An example of the use of this is shown in the below expo snack, where I am disabling base snapping, and using snapToItem to get around the default snapping behavior on iOS (this may be something that should be tackled separately, but using it as a more specific example).

Snack created by taking version 3.9.1 and importing it directly, changing the three lines of code proposed (couldn't find a way to use the forked repo)
[https://snack.expo.io/@jmkiser/carousel-swiping](https://snack.expo.io/@jmkiser/carousel-swiping)

### What testing has been done on this change?
Tested on several android devices/sims + iOS Sims and iPhone 8

### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [x] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [x] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [x] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [x] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [x] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [x] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [x] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [x] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [x] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-carousel#parallaximage-component)
- [x] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-component)
- [x] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-carousel#layouts-and-custom-interpolations)
